### PR TITLE
Remove deprecated gulp-util dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var through = require('through2');
-var PluginError = require('gulp-util').PluginError;
+var PluginError = require('plugin-error');
 var EOL = require('os').EOL;
 
 module.exports = function (eol, append) {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "newline"
   ],
   "dependencies": {
-    "gulp-util": "~2.2",
+    "plugin-error": "~1.0",
     "through2": "~0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
According to https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5 gulp-util is deprecated now. Please consider updating dependencies.